### PR TITLE
BEL-47760 Remove the create smaller image option

### DIFF
--- a/public/js/index.js
+++ b/public/js/index.js
@@ -513,9 +513,7 @@ function onGenerate2() {
   ResultImage = $('<div id="image-div" class="center-block"></div>');
   ResultImage.addClass('result-image');
 
-
-  var b = document.getElementById('bom-image-size');
-  var outputSize = (b.checked == true) ? 300 : 600;
+  var outputSize = 600;
 
   var options = "?documentId=" + theContext.documentId + "&workspaceId=" + theContext.workspaceId + "&elementId=" + theContext.elementId +
       "&outputHeight=" + outputSize + "&outputWidth=" + outputSize + "&pixelSize=" + realSize / outputSize +

--- a/views/index.html
+++ b/views/index.html
@@ -34,7 +34,6 @@
                   </select>
                   <span class ="bom-inputs">
                       <span class="bom-input"><input type="checkbox" id="bom-component-collapse">Combine components by name</span>
-                      <span class="bom-input"><input type="checkbox" id="bom-image-size">Create smaller image</span>
                   </span>
                   <div class="options" id="options_panel">
                       <button class="btn btn-default btn-sm clearfix bom-btn" id="element-save-csv">Save as CSV</button>


### PR DESCRIPTION
Remove the create smaller image option and instead create an image of a single size. Since the app is responsive it is easier to view a single image on a smaller screen. There would however now only be a single image size in the print preview.